### PR TITLE
Change scroll threshold for sticky header effect

### DIFF
--- a/js/site.js
+++ b/js/site.js
@@ -54,7 +54,7 @@
   // Scroll state (for sticky header shadow + animated shrink)
   var lastScrolled = false;
   function onScroll() {
-    var scrolled = window.scrollY > 8;
+    var scrolled = window.scrollY > 20;
     if (scrolled !== lastScrolled) {
       body.classList.toggle('scrolled', scrolled);
       lastScrolled = scrolled;


### PR DESCRIPTION
Temporary fix.
The bug still occurs but it will not be triggered by one native "1 step wheel scroll" down/up.