### PR TITLE
Restore hero parallax and the full set of hero classes lost in the Quark 2 rebuild

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+# v1.1.6
+## 07/20/2026
+
+1. [](#new)
+    * Restored the full set of hero classes from the original Quark theme, so `hero-fullscreen`, the hero size options, `text-light`/`text-dark`, `title-h1h2`, and the image overlays all work again ([#18](https://github.com/getgrav/grav-theme-quark2/issues/18)).
+2. [](#bugfix)
+    * The hero background parallax effect now works again; it was lost when the theme was rebuilt for Grav 2.0 ([#17](https://github.com/getgrav/grav-theme-quark2/issues/17)).
+
 # v1.1.5
 ## 07/17/2026
 

--- a/blueprints.yaml
+++ b/blueprints.yaml
@@ -1,7 +1,7 @@
 name: Quark 2
 slug: quark2
 type: theme
-version: 1.1.5
+version: 1.1.6
 description: The modernized Grav default theme — Blades CSS foundation, Cal.com-inspired aesthetic, with light/dark/auto mode and Font Awesome 7 icons.
 icon: meteor
 author:

--- a/css/theme.css
+++ b/css/theme.css
@@ -1087,6 +1087,84 @@ body.overlay-open {
   color: #ffffff;
 }
 
+/* Hero modifier classes (hero_classes) — parity with Quark 1 (#18) */
+
+/* Height presets */
+.hero.hero-fullscreen {
+  min-height: 100dvh;
+}
+.hero.hero-large {
+  min-height: clamp(30rem, 60vh, 34rem);
+}
+.hero.hero-medium {
+  min-height: clamp(24rem, 48vh, 27rem);
+}
+.hero.hero-small {
+  min-height: 7rem;
+}
+.hero.hero-tiny {
+  min-height: 5rem;
+}
+
+/* Foreground presets (theme-independent — for text over imagery) */
+.hero.text-light h1,
+.hero.text-light h2,
+.hero.text-light h3 {
+  color: #ffffff;
+}
+.hero.text-light p,
+.hero.text-light .lead {
+  color: color-mix(in oklab, #ffffff 78%, transparent);
+}
+.hero.text-dark h1,
+.hero.text-dark h2,
+.hero.text-dark h3 {
+  color: var(--q2-text-strong, #111111);
+}
+.hero.text-dark p,
+.hero.text-dark .lead {
+  color: color-mix(in oklab, #242424 72%, transparent);
+}
+
+/* Close h1/h2 title pairing */
+.title-h1h2 h1 {
+  font-weight: 100;
+  margin-bottom: 0;
+  line-height: 1.1;
+}
+.title-h1h2 h1 strong,
+.title-h1h2 h1 b {
+  font-weight: 400;
+}
+.title-h1h2 h1 + h2 {
+  margin-top: 0;
+  margin-bottom: 3rem;
+  line-height: 1.1;
+  font-weight: 700;
+}
+
+/* Image-overlay tints — only meaningful on heroes with a background image */
+.hero[style*="background-image"].overlay-light .image-overlay {
+  background: color-mix(in oklab, #ffffff 40%, transparent);
+}
+.hero[style*="background-image"].overlay-light-gradient .image-overlay {
+  background: linear-gradient(
+    to bottom,
+    color-mix(in oklab, #ffffff 50%, transparent),
+    color-mix(in oklab, #ffffff 20%, transparent)
+  );
+}
+.hero[style*="background-image"].overlay-dark .image-overlay {
+  background: color-mix(in oklab, #000000 40%, transparent);
+}
+.hero[style*="background-image"].overlay-dark-gradient .image-overlay {
+  background: linear-gradient(
+    to bottom,
+    color-mix(in oklab, #000000 50%, transparent),
+    color-mix(in oklab, #000000 20%, transparent)
+  );
+}
+
 .hero .container {
   position: relative;
   z-index: 1;

--- a/js/site.js
+++ b/js/site.js
@@ -51,6 +51,21 @@
     });
   }
 
+  // Background parallax for hero sections tagged `.parallax`.
+  // Vanilla port of Quark 1's parallaxBackground(); rAF-throttled and
+  // disabled when the visitor prefers reduced motion. Driven off the same
+  // scroll listener as the scroll-state below so there's only one handler.
+  var parallaxNodes = document.querySelectorAll('.hero.parallax');
+  var parallaxOn = parallaxNodes.length && !matchMedia('(prefers-reduced-motion: reduce)').matches;
+  var parallaxTicking = false;
+  function applyParallax() {
+    var offset = window.scrollY * 0.3;
+    parallaxNodes.forEach(function (el) {
+      el.style.backgroundPositionY = offset + 'px';
+    });
+    parallaxTicking = false;
+  }
+
   // Scroll state (for sticky header shadow + animated shrink)
   // Hysteresis: the navbar shrinks by 12px when `.scrolled` is on, which
   // shifts layout and can flip scrollY back over a single threshold. The
@@ -65,6 +80,10 @@
     if (scrolled !== lastScrolled) {
       body.classList.toggle('scrolled', scrolled);
       lastScrolled = scrolled;
+    }
+    if (parallaxOn && !parallaxTicking) {
+      window.requestAnimationFrame(applyParallax);
+      parallaxTicking = true;
     }
   }
   window.addEventListener('scroll', onScroll, { passive: true });


### PR DESCRIPTION
Quark 2 was rebuilt on a new CSS foundation and the hero template still emits `hero_classes` / `.parallax`, but the JS and CSS behind them were never ported.

- Restores the background parallax handler (vanilla JS, rAF-throttled, `prefers-reduced-motion`-aware), driven off the existing scroll listener.
- Re-authors the hero modifier classes against Quark 2's design tokens: `hero-fullscreen`, `hero-large/-medium/-small/-tiny`, `text-light/-dark`, `title-h1h2`, and the `overlay-*` image overlays.

Fixes #17
Fixes #18