### PR TITLE
fix(modular-features): make header.class actually control column width

### DIFF
--- a/css/theme.css
+++ b/css/theme.css
@@ -2189,6 +2189,9 @@ input:focus {
   grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
   margin-top: 2.5rem;
 }
+.modular-features[data-layout="standard"] .columns {
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+}
 .modular-features .column {
   background: var(--q2-bg-elev);
   border-radius: var(--q2-radius-md);

--- a/templates/modular/features.html.twig
+++ b/templates/modular/features.html.twig
@@ -1,4 +1,4 @@
-<section class="section modular-features {{ page.header.class }}">
+<section class="section modular-features" data-layout="{{ page.header.class|default('small') }}">
     <div class="container">
         <div class="frame-box">
             {{ content|raw }}


### PR DESCRIPTION
## Problem

In the `modular-features` template, `page.header.class` was appended
directly as a CSS class on the section:

```twig
<section class="section modular-features {{ page.header.class }}">
```

However, theme.css had no rule that used this class in any way to
affect the columns grid. The grid always used a single default rule:

```css
.modular-features .columns {
  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
}
```

As a result, setting `header.class` (e.g. to `standard`) in a page's
frontmatter had no visible effect — the number/width of columns was
driven purely by viewport width via `auto-fit`, regardless of the
value of `header.class`.

## Fix

Render `page.header.class` as a `data-layout` attribute instead of a
raw class, and add a CSS rule that responds to it:

```twig
<section class="section modular-features" data-layout="{{ page.header.class|default('small') }}">
```

```css
.modular-features[data-layout="standard"] .columns {
  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
}
```

The `class` key in the page frontmatter is unchanged — only how it's
consumed on the template/CSS side changes, so existing content
doesn't need to be updated.

## Behavior

- `header.class` unset or `small` (default): `minmax(220px, 1fr)` — more, narrower columns.
- `header.class: standard`: `minmax(280px, 1fr)` — fewer, wider columns.

Both remain fluid (`auto-fit`), so column count still adapts
responsively per breakpoint; `standard` just raises the minimum
column width.

## Testing

- Verified `data-layout` attribute renders correctly for both values.
- Confirmed via DevTools computed styles that `grid-template-columns`
  switches between 220px and 280px minmax depending on `header.class`.
- No changes required to existing page frontmatter — fully backward
  compatible.